### PR TITLE
fix compose-desktop gradle run task

### DIFF
--- a/compose-desktop/build.gradle.kts
+++ b/compose-desktop/build.gradle.kts
@@ -18,10 +18,12 @@ dependencies {
     implementation(compose.desktop.currentOs)
 }
 
-tasks.withType<KotlinCompile>() {
+tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
 }
 
 application {
-    mainClassName = "mainKt"
+    mainClass.set("MainKt")
 }
+
+tasks.getByName<JavaExec>("run").workingDir=project.rootDir


### PR DESCRIPTION
classname was misspelled, it did not find roms because the working dir was the subproject
./gradlew c-d: c-d:run